### PR TITLE
Show menu bar when Alt is pressed

### DIFF
--- a/menu-bar.patch
+++ b/menu-bar.patch
@@ -1,11 +1,10 @@
-diff --git a/build/main.js b/build/main.js
-index a229f52..0f1955b 100644
 --- a/build/main.js
 +++ b/build/main.js
-@@ -4580,6 +4580,7 @@ module.exports = (function(modules) {
+@@ -4541,6 +4541,8 @@
                  .setAutoResize({ width: !0, height: !0 }))
              : this.appService.setWindow(this.window, void 0),
            this.appService.setUserAgent(),
++          this.window.setAutoHideMenuBar(true),
 +          this.window.setMenuBarVisibility(false),
            isPlatform(PLATFORM_DARWIN)
              ? this.window.on("moved", () => {


### PR DESCRIPTION
Hiding the menu bar is aesthetically nice, but it's still needed to check the app's version number. This commit keeps the menu bar hidden by default but also allows the user to show it when necessary by pressing the <kbd>Alt</kbd> key.